### PR TITLE
ci: Add github action workflow to build bmw_telemetry

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,27 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "mainline" ]
+  pull_request:
+    branches: [ "mainline" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install thumbv7em toolchain
+      run: rustup target add thumbv7em-none-eabihf
+    - name: Build
+      run: cargo build --verbose
+    # Don't bother running tests for now because our crate does not have any
+    #
+    # todo: #4 uncomment this when we have some tests
+    # - name: Run tests
+    #   run: cargo test --verbose


### PR DESCRIPTION
Problem: We don't currently have a workflow to automatically prove new commits or pull requests will build.

Solution: Use a GitHub action workflow to build our code.

Testing: This workflow [successfully built on commit](https://github.com/ophilli/bmw_telemetry/actions/runs/12500808465/job/34877445121) to my fork.